### PR TITLE
Use entry index to find entries in socket, remove forgot password endpoint

### DIFF
--- a/apps/dert_gg_web/lib/dert_gg_web/components/row.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/components/row.ex
@@ -3,8 +3,8 @@ defmodule DertGGWeb.Components.Row do
 
   def row(assigns) do
     ~H"""
-    <tr class="table-hover" phx-click="show-modal" phx-value-entry={@entry.id}>
-      <td scope="row"><%= @num %></td>
+    <tr class="table-hover" phx-click="show-modal" phx-value-entry-index={@entry_index}>
+      <td scope="row"><%= @entry_index %></td>
       <td><div class="entry-content"><%= @entry.text_content %></div></td>
       <td><%= @vote_count %></td>
     </tr>

--- a/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.ex
@@ -18,17 +18,17 @@ defmodule DertGGWeb.DertsLive do
     {:noreply, assign(socket, :entries, entries)}
   end
 
-  def handle_event("close-modal", %{} = _params, socket) do
+  def handle_event("close-modal", _params, socket) do
     {:noreply, push_patch(socket, to: "/", show_modal: false)}
   end
 
-  def handle_event("show-modal", %{} = params, socket) do
-    {:noreply, push_patch(socket, to: "/top-10/#{params["entry"]}", show_modal: true)}
+  def handle_event("show-modal", %{"entry-index" => entry_index}, socket) do
+    {:noreply, push_patch(socket, to: "/top-10/#{entry_index}", show_modal: true)}
   end
 
-  def handle_params(%{"entry_id" => entry_id}, _uri, socket) do
-    with {entry_id, _binary} <- Integer.parse(entry_id),
-         {:ok, entry} <- find_entry(socket.assigns.entries, entry_id) do
+  def handle_params(%{"entry_index" => entry_index}, _uri, socket) do
+    with {entry_index, _binary} <- Integer.parse(entry_index),
+         {:ok, entry} <- find_entry(socket.assigns.entries, entry_index) do
       {:noreply, assign(socket, show_modal: true, entry: entry)}
     else
       _ -> {:noreply, push_patch(socket, to: "/", show_modal: false)}
@@ -41,10 +41,10 @@ defmodule DertGGWeb.DertsLive do
 
   # TODO: Fix this mess, use virtual field maybe for vote_count within entry
   @type entry :: %{entry: map(), vote_count: number()}
-  @spec find_entry([entry], entry_id :: number()) ::
+  @spec find_entry([entry], entry_index :: number()) ::
           {:ok, map()} | {:error, :entry_not_found}
-  defp find_entry(entries, entry_id) do
-    case Enum.find(entries, &(&1.entry.id == entry_id)) do
+  defp find_entry(entries, entry_index) do
+    case Enum.at(entries, entry_index - 1) do
       nil -> {:error, :entry_not_found}
       entry -> {:ok, entry.entry}
     end

--- a/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.html.heex
+++ b/apps/dert_gg_web/lib/dert_gg_web/live/derts_live.html.heex
@@ -9,7 +9,7 @@
     </thead>
     <tbody>
       <%= for {%{entry: entry, vote_count: vote_count}, index} <- Enum.with_index(@entries, 1) do %>
-        <.row entry={entry} vote_count={vote_count} num={index} />
+        <.row entry={entry} vote_count={vote_count} entry_index={index} />
       <% end %>
     </tbody>
   </table>

--- a/apps/dert_gg_web/lib/dert_gg_web/router.ex
+++ b/apps/dert_gg_web/lib/dert_gg_web/router.ex
@@ -35,10 +35,10 @@ defmodule DertGGWeb.Router do
     end
 
     live "/", DertsLive
-    live "/top-10/:entry_id", DertsLive
+    live "/top-10/:entry_index", DertsLive
 
     resources "/login", SessionController, only: [:new, :create]
-    resources "/password-reset", PasswordResetController, only: [:new, :create, :update, :edit]
+    # resources "/password-reset", PasswordResetController, only: [:new, :create, :update, :edit]
     resources "/register", RegistrationController, only: [:new, :create]
   end
 


### PR DESCRIPTION
Instead of using entry ID, use index of the entry in top-10 list to find the entry.
This way it's easier and also the URL looks better on top-10 with appropriate index.

Also removed forgot password endpoint.